### PR TITLE
fix: logger function should accept second arguments

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -59,7 +59,7 @@ export declare type HandlerFunction = (
   res: Response,
   next?: NextFunction
 ) => void | any | Promise<any>;
-export declare type LoggerFunction = (message: string) => void;
+export declare type LoggerFunction = (message?: any, ...optionalParams: any[]) => void;
 export declare type NextFunction = () => void;
 export declare type TimestampFunction = () => string;
 export declare type SerializerFunction = (body: object) => string;


### PR DESCRIPTION
Docs show that we could add a second argument in the logger, it's working fine in JS but in TS the typing was only accepting string arguments